### PR TITLE
Resolve ${varName} in sparqlAsk and sparqlQuery text before parsing

### DIFF
--- a/src/main/java/io/github/qudtlib/maven/rdfio/pipeline/step/SparqlQueryStep.java
+++ b/src/main/java/io/github/qudtlib/maven/rdfio/pipeline/step/SparqlQueryStep.java
@@ -113,6 +113,7 @@ public class SparqlQueryStep implements Step {
                 throw new MojoExecutionException(
                         "SPARQL query is required in sparqlQuery step - neither <sparql> nor <file> element had a query");
             }
+            sparqlString = state.variables().resolve(sparqlString, dataset);
             SparqlHelper.QueryResultProcessor resultProcessor =
                     new SparqlHelper.QueryResultProcessor() {
                         @Override

--- a/src/main/java/io/github/qudtlib/maven/rdfio/pipeline/step/UntilStep.java
+++ b/src/main/java/io/github/qudtlib/maven/rdfio/pipeline/step/UntilStep.java
@@ -87,7 +87,7 @@ public class UntilStep implements Step {
                 for (Step step : body) {
                     step.executeAndWrapException(dataset, state);
                 }
-                String sparqlAskString = this.sparqlAsk;
+                String sparqlAskString = state.variables().resolve(this.sparqlAsk, dataset);
                 SparqlHelper.executeSparqlQueryWithVariables(
                         sparqlAskString,
                         dataset,

--- a/src/main/java/io/github/qudtlib/maven/rdfio/pipeline/step/WhenStep.java
+++ b/src/main/java/io/github/qudtlib/maven/rdfio/pipeline/step/WhenStep.java
@@ -58,7 +58,7 @@ public class WhenStep implements Step {
             state.log().info(state.variables().resolve(message, dataset), 1);
         }
         boolean[] result = new boolean[] {false};
-        String sparqlAskString = this.sparqlAsk;
+        String sparqlAskString = state.variables().resolve(this.sparqlAsk, dataset);
         SparqlHelper.executeSparqlQueryWithVariables(
                 sparqlAskString,
                 dataset,


### PR DESCRIPTION
We've been testing the `contrib/stepdef-env` branch (built locally as `1.6.3-SNAPSHOT`) against a real pipeline in qudt-public-repo. 
(The 1.7.0-rc.1 CHANGELOG entry is empty and our step classes appear to be missing from that branch.)

The new steps work well overall. Three issues came up that are worth sharing.
---
**1. `${varName}` substitution is missing in `WhenStep`, `UntilStep`, and `SparqlQueryStep`**
In a `<forEachEnv>` body, `${varName}` appears not just in `<sparqlUpdate>` text but also in the `<sparqlAsk>` conditions of `<when>` and `<until>`, and in `<sparqlQuery>` text. For example:
```xml
<forEachEnv>
    <env id="symbol">
        <property name="name">symbol</property>
    </env>
    <body>
        <when>
            <sparqlAsk><![CDATA[
                ASK { GRAPH <delete:${name}> { [] sh:conforms false } }
            ]]></sparqlAsk>
            ...
        </when>
    </body>
</forEachEnv>
```
The `${name}` in the ASK text is not resolved before SPARQL parsing, causing a parse error. The same issue occurs in `<until>` and `<sparqlQuery>`. `SparqlUpdateStep` already handles this correctly; the same one-line fix is needed in the other three steps.
**Fix for `WhenStep.execute()`:**
```java
// BEFORE
String sparqlAskString = this.sparqlAsk;
// AFTER
String sparqlAskString = state.variables().resolve(this.sparqlAsk, dataset);
```
**Fix for `UntilStep.execute()`:** same pattern — resolve `this.sparqlAsk` before passing to `executeSparqlQueryWithVariables`.
**Fix for `SparqlQueryStep.execute()`:**
```java
// BEFORE
// (after sparqlString is determined from this.sparql or file)
SparqlHelper.executeSparqlQueryWithVariables(sparqlString, ...);
// AFTER
sparqlString = state.variables().resolve(sparqlString, dataset);
SparqlHelper.executeSparqlQueryWithVariables(sparqlString, ...);
```
`ClearStep` is already fine — it routes through `PipelineHelper.collectAllGraphReferences()` which already calls `state.variables().resolve()` on every graph name. The fix is fully backward-compatible: `resolve()` is a no-op when the input contains no `${`.
**What we did:** Applied these three fixes locally to `contrib/stepdef-env` for our test build. 

There are two other issues, regarding resolution of variables, but I'm holding off on submitting another PR until we are satisfied with this fix first.

