### PR TITLE
Execute <stepDef> registration before savepoint evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `<stepDef>` registrations are no longer lost when the pipeline resumes from a `<savepoint>`. Resuming skips all steps preceding the savepoint, which skipped the `<stepDef>` registration itself and made any later `<invoke>` fail with "no `<stepDef id="...">` has been registered". Steps implementing the new marker interface `ExecuteBeforeSavepointEvaluation` (currently `StepDefStep`) are now executed before savepoint evaluation and skipped by the main execution loop. Step hashes and savepoint validity are unaffected.
 
 ## [1.7.0] - 2026-05-09
 

--- a/src/main/java/io/github/qudtlib/maven/rdfio/pipeline/PipelineMojo.java
+++ b/src/main/java/io/github/qudtlib/maven/rdfio/pipeline/PipelineMojo.java
@@ -3,6 +3,7 @@ package io.github.qudtlib.maven.rdfio.pipeline;
 import io.github.qudtlib.maven.rdfio.common.RDFIO;
 import io.github.qudtlib.maven.rdfio.common.file.RelativePath;
 import io.github.qudtlib.maven.rdfio.common.sparql.SparqlHelper;
+import io.github.qudtlib.maven.rdfio.pipeline.step.ExecuteBeforeSavepointEvaluation;
 import io.github.qudtlib.maven.rdfio.pipeline.step.SavepointStep;
 import io.github.qudtlib.maven.rdfio.pipeline.step.Step;
 import io.github.qudtlib.maven.rdfio.pipeline.step.support.ParsingHelper;
@@ -137,6 +138,15 @@ public class PipelineMojo extends AbstractMojo {
             updatePipelineState(state, project);
             state.setAllowLoadingFromSavepoint(!pipeline.isForceRun());
 
+            // Execute steps that must run before savepoint evaluation, such as <stepDef>
+            // registration. Resuming at a savepoint skips all preceding steps, which would
+            // otherwise leave the state they establish unavailable to later steps.
+            for (Step step : pipeline.getSteps()) {
+                if (step instanceof ExecuteBeforeSavepointEvaluation) {
+                    step.executeAndWrapException(dataset, state);
+                }
+            }
+
             int startIndex = -1;
             List<String> stepHashes = new ArrayList<>();
 
@@ -254,6 +264,11 @@ public class PipelineMojo extends AbstractMojo {
                 Step step = pipeline.getSteps().get(i);
                 state.setPreviousStepHash(previousHash);
                 previousHash = step.calculateHash(previousHash, state);
+                if (step instanceof ExecuteBeforeSavepointEvaluation) {
+                    // already executed before savepoint evaluation; the hash chain is still
+                    // advanced above so savepoint validity is unaffected
+                    continue;
+                }
                 step.executeAndWrapException(dataset, state);
             }
         } catch (Throwable throwable) {

--- a/src/main/java/io/github/qudtlib/maven/rdfio/pipeline/step/ExecuteBeforeSavepointEvaluation.java
+++ b/src/main/java/io/github/qudtlib/maven/rdfio/pipeline/step/ExecuteBeforeSavepointEvaluation.java
@@ -1,0 +1,19 @@
+package io.github.qudtlib.maven.rdfio.pipeline.step;
+
+/**
+ * Marker interface for steps whose {@link Step#execute} must be called before savepoint evaluation.
+ *
+ * <p>Steps implementing this interface are executed once, up front, on every run — before step
+ * hashes are calculated and before a resume point is selected — and are then skipped by the main
+ * execution loop. This is required for steps that only establish state needed by later steps
+ * (rather than modifying the dataset), because resuming at a {@code <savepoint>} skips every
+ * preceding step and would otherwise lose that state.
+ *
+ * <p>{@link StepDefStep} implements this: its {@code execute()} registers the step definition for
+ * later use by {@link InvokeStep}, so without early execution an {@code <invoke>} following the
+ * resume point would fail with "no &lt;stepDef&gt; has been registered".
+ *
+ * <p>Implementations must be idempotent and must not depend on dataset content, as they run before
+ * any savepoint data is loaded.
+ */
+public interface ExecuteBeforeSavepointEvaluation extends Step {}

--- a/src/main/java/io/github/qudtlib/maven/rdfio/pipeline/step/StepDefStep.java
+++ b/src/main/java/io/github/qudtlib/maven/rdfio/pipeline/step/StepDefStep.java
@@ -28,8 +28,12 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
  * }</pre>
  *
  * The {@code <stepDef>} must appear before any {@code <invoke>} that references it.
+ *
+ * <p>Registration happens before savepoint evaluation (see {@link
+ * ExecuteBeforeSavepointEvaluation}), so an {@code <invoke>} still works when the pipeline resumes
+ * at a {@code <savepoint>} that follows the {@code <stepDef>}.
  */
-public class StepDefStep implements Step {
+public class StepDefStep implements ExecuteBeforeSavepointEvaluation {
     private String id;
     private final List<Step> steps = new ArrayList<>();
 

--- a/src/test/java/io/github/qudtlib/maven/rdfio/pipeline/StepDefSavepointResumeTests.java
+++ b/src/test/java/io/github/qudtlib/maven/rdfio/pipeline/StepDefSavepointResumeTests.java
@@ -1,0 +1,81 @@
+package io.github.qudtlib.maven.rdfio.pipeline;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test: a {@code <stepDef>} declared before a {@code <savepoint>} must still be
+ * registered when the pipeline resumes at that savepoint, so that an {@code <invoke>} placed after
+ * the savepoint can execute.
+ *
+ * <p>Before the fix, resuming skipped every step preceding the savepoint — including the {@code
+ * <stepDef>}, whose {@code execute()} performs the registration — so the later {@code <invoke>}
+ * failed with "no &lt;stepDef id="..."&gt; has been registered".
+ */
+public class StepDefSavepointResumeTests {
+
+    private static final String CONFIG_FILE =
+            "src/test/resources/pipeline-config-stepdef-savepoint.xml";
+
+    private static final Path INVOKED_OUTPUT = Path.of("target/stepdef-savepoint-invoked.ttl");
+
+    private File baseDir;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        baseDir = new File(".");
+        Files.deleteIfExists(INVOKED_OUTPUT);
+    }
+
+    @Test
+    void invokeAfterSavepointWorksWhenResuming() throws Exception {
+        // First run: forceRun disables resuming, so the whole pipeline executes and the
+        // <savepoint> is written.
+        PipelineMojo firstRun = newMojo();
+        firstRun.getPipeline().setForceRun(true);
+        firstRun.execute();
+        assertTrue(
+                Files.exists(INVOKED_OUTPUT),
+                "<invoke> should have executed during the initial (non-resuming) run");
+        Files.delete(INVOKED_OUTPUT);
+
+        // Second run: resumes at the <savepoint>, which sits after the <stepDef> and before the
+        // <invoke>.
+        PipelineMojo resumedRun = newMojo();
+        resumedRun.getPipeline().setForceRun(false);
+        resumedRun.execute();
+
+        assertTrue(
+                Files.exists(INVOKED_OUTPUT),
+                "<invoke> should still execute after resuming from the savepoint");
+        assertTrue(
+                Files.readString(INVOKED_OUTPUT).contains("http://example.org/invoked"),
+                "the triple inserted by the invoked <stepDef> should be present after resuming");
+    }
+
+    private PipelineMojo newMojo() throws Exception {
+        PipelineMojo mojo = new PipelineMojo();
+        mojo.setBaseDir(baseDir);
+        mojo.setWorkBaseDir(new File("target"));
+        setField(
+                mojo,
+                "configuration",
+                Xpp3DomBuilder.build(Files.newInputStream(Path.of(CONFIG_FILE)), "UTF-8"));
+        setField(mojo, "baseDir", baseDir);
+        mojo.parseConfiguration();
+        return mojo;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/src/test/resources/pipeline-config-stepdef-savepoint.xml
+++ b/src/test/resources/pipeline-config-stepdef-savepoint.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <pipeline>
+        <id>stepdef-savepoint-pipeline</id>
+        <steps>
+            <stepDef id="add-invoked-triple">
+                <sparqlUpdate>
+                    <sparql>INSERT DATA { GRAPH &lt;test:invoked&gt; { &lt;http://example.org/invoked&gt; &lt;http://example.org/p&gt; &lt;http://example.org/o&gt; } }</sparql>
+                </sparqlUpdate>
+            </stepDef>
+            <add>
+                <file>src/test/resources/data.ttl</file>
+                <toGraph>test:graph</toGraph>
+            </add>
+            <savepoint>
+                <id>spBeforeInvoke</id>
+            </savepoint>
+            <invoke stepRef="add-invoked-triple"/>
+            <write>
+                <graph>test:invoked</graph>
+                <toFile>target/stepdef-savepoint-invoked.ttl</toFile>
+            </write>
+        </steps>
+    </pipeline>
+</configuration>


### PR DESCRIPTION
Fixes the `<stepDef>`/`<invoke>` vs. savepoint-resume bug reported on Slack. Implements option 1 (pre-scan/register up front) with the marker interface and the test you asked for.

## The bug

Resuming at a `<savepoint>` starts execution at the savepoint's step index and skips every preceding step. `<stepDef>` registration *is* a step (`StepDefStep.execute()` → `state.registerStepDef(...)`), so a `<stepDef>` declared before the resume point is never registered and any later `<invoke>` fails with:

```
<invoke stepRef="x">: no <stepDef id="x"> has been registered. Ensure the <stepDef> appears before <invoke> in the pipeline.
```

Because a stepDef is typically declared once near the top and invoked several times downstream, this makes savepoint resume unusable in any pipeline using `<stepDef>`/`<invoke>`. The only workaround was `-Drdfio.pipeline.forceRun=true`, which forfeits the savepoint speedup.

## The fix

- New marker interface **`ExecuteBeforeSavepointEvaluation extends Step`**, for steps whose `execute()` must be called before savepoint evaluation. `StepDefStep` implements it; anything else needing the same treatment later just implements the interface.
- `PipelineMojo` executes all such steps up front — **before** step hashes are calculated and **before** the resume point is selected — and **skips** them in the main execution loop, so they run exactly once no matter where execution resumes.

Two properties worth noting:

- **Savepoint semantics are untouched.** The main loop still advances the hash chain for these steps before skipping, so step hashes and savepoint validity are byte-identical to before. No savepoint format change, so existing savepoints stay valid.
- **The pre-pass runs unconditionally**, including under `forceRun`, so cold and resumed runs behave identically — no double registration, no duplicate log lines.

Scope note: the pre-pass walks **top-level steps only**, consistent with the existing default-savepoint-id assignment loop. A `<stepDef>` nested inside e.g. a `<forEach>` body keeps its current behaviour. Happy to recurse into container steps instead if you'd prefer.

## Test

`StepDefSavepointResumeTests` runs a pipeline ordered `<stepDef>`, `<add>`, `<savepoint>`, `<invoke>`, `<write>` twice against the same target directory — the first with `forceRun` (writes the savepoint), the second resuming from it — mirroring the two-Maven-invocation CI case. It asserts the `<invoke>` still executes and its triple reaches the written file.

- **Without the fix** it fails with exactly the error above, after logging `Latest valid <savepoint> is 'spBeforeInvoke' (step 3/5) ... Resuming pipeline at savepoint`.
- **With the fix** it passes.

Full suite: 207/207 green, spotless clean.